### PR TITLE
Fix button ISR queue race and ES8388 mute register

### DIFF
--- a/modules/32bit/code/32bit/main/src/bm_es8388.c
+++ b/modules/32bit/code/32bit/main/src/bm_es8388.c
@@ -163,8 +163,13 @@ esp_err_t bm_es8388_input_select(bm_es8388_t *es, insel_t sel) {
 
 esp_err_t bm_es8388_dac_mute(bm_es8388_t *es, bool mute) {
   uint8_t reg = 0;
-  if (bm_es8388_read_reg(es, ES8388_ADCCONTROL1, &reg) != ESP_OK) return ESP_FAIL;
-  return bm_es8388_write_reg(es, ES8388_DACCONTROL3, mute ? (reg | 0x04) : (reg & ~(0x04)));
+  if (bm_es8388_read_reg(es, ES8388_DACCONTROL3, &reg) != ESP_OK) return ESP_FAIL;
+  if (mute) {
+    reg |= 0x04;
+  } else {
+    reg &= ~(0x04);
+  }
+  return bm_es8388_write_reg(es, ES8388_DACCONTROL3, reg);
 }
 
 esp_err_t bm_es8388_set_output_volume(bm_es8388_t *es, uint8_t vol) {


### PR DESCRIPTION
## Summary
- guard the button ISR against a missing queue and create the queue before enabling interrupts
- read and modify ES8388_DACCONTROL3 when toggling the DAC mute bit

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68faae02959c8320be16ad04555aed5c